### PR TITLE
Spawning, de-spawning and moving zombies

### DIFF
--- a/godot/Player.tscn
+++ b/godot/Player.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://icon.png" type="Texture" id=1]
 
 [sub_resource type="CircleShape2D" id=1]
-radius = 82
+radius = 82.0
 
 [node name="Player" type="Node2D"]
 modulate = Color( 1, 1, 1, 0.784314 )
@@ -11,6 +11,7 @@ modulate = Color( 1, 1, 1, 0.784314 )
 [node name="Camera2D" type="Camera2D" parent="."]
 rotating = true
 current = true
+zoom = Vector2( 4, 4 )
 
 [node name="Icon" type="Sprite" parent="."]
 texture = ExtResource( 1 )

--- a/godot/main.tscn
+++ b/godot/main.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://Player.tscn" type="PackedScene" id=1]
-[ext_resource path="res://Zombie.tscn" type="PackedScene" id=2]
 [ext_resource path="res://Level.tscn" type="PackedScene" id=3]
 [ext_resource path="res://Airdrop.tscn" type="PackedScene" id=4]
 
@@ -24,22 +23,6 @@ margin_bottom = 20.0
 [node name="Level" parent="." instance=ExtResource( 3 )]
 
 [node name="Player" parent="." instance=ExtResource( 1 )]
-
-[node name="Zombie3" parent="." instance=ExtResource( 2 )]
-position = Vector2( 10, 1460 )
-rotation = 4.71239
-
-[node name="Zombie4" parent="." instance=ExtResource( 2 )]
-position = Vector2( 1578, -133 )
-rotation = 4.71239
-
-[node name="Zombie6" parent="." instance=ExtResource( 2 )]
-position = Vector2( 5, -1369 )
-rotation = 4.71239
-
-[node name="Zombie5" parent="." instance=ExtResource( 2 )]
-position = Vector2( -1316, 90 )
-rotation = 4.71239
 
 [node name="Airdrop" parent="." instance=ExtResource( 4 )]
 position = Vector2( 355, -105 )

--- a/src/zombies.rs
+++ b/src/zombies.rs
@@ -1,20 +1,14 @@
 use std::f32::consts::PI;
 
-use crate::{
-    player::Player,
-    Hp,
-};
-use bevy_godot::prelude::{
-    bevy_prelude::*,
-    godot_prelude::Vector2,
-    *,
-};
+use crate::{player::Player, Hp};
+use bevy_godot::prelude::{bevy_prelude::*, godot_prelude::Vector2, *};
 use rand::prelude::*;
 
 pub struct ZombiesPlugin;
 impl Plugin for ZombiesPlugin {
     fn build(&self, app: &mut App) {
         app.add_system(label_zombies)
+            .add_startup_system(spawn_zombies)
             .add_system(zombies_move.as_physics_system())
             .add_system(kill_zombies.as_physics_system())
             .add_system(zombie_targeting.as_physics_system());
@@ -36,6 +30,21 @@ impl Target {
         let vector = Vector2::UP.rotated(direction) * distance;
         Self(vector)
     }
+}
+
+fn spawn_zombies(mut commands: Commands) {
+    commands
+        .spawn()
+        .insert(GodotScene::from_path("res://Zombie.tscn"))
+        .insert(Zombie)
+        .insert(Target::random())
+        .insert(Transform2D(
+            GodotTransform2D::from_rotation_translation_scale(
+                Vector2 { x: 0.0, y: -200.0 },
+                0.0,
+                Vector2::ONE,
+            ),
+        ));
 }
 
 fn label_zombies(
@@ -83,8 +92,7 @@ fn zombie_targeting(
         let player = player.single();
         if zombie.origin.distance_to(player.origin) < 500.0 {
             *target = Target(player.origin);
-        }
-        else if zombie.origin.distance_to(target.0) < 200.0 {
+        } else if zombie.origin.distance_to(target.0) < 200.0 {
             // TODO: Make the new random close to the current zombie position
             *target = Target::random();
         }

--- a/src/zombies.rs
+++ b/src/zombies.rs
@@ -7,7 +7,7 @@ use rand::prelude::*;
 pub struct ZombiesPlugin;
 impl Plugin for ZombiesPlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(SpawnTimer(Timer::from_seconds(1.0, true)))
+        app.insert_resource(SpawnTimer(Timer::from_seconds(10.0, true)))
             .add_system(spawn_zombies.as_physics_system())
             .add_system(zombies_move.as_physics_system())
             .add_system(despawn_faraway_zombies.as_physics_system())

--- a/src/zombies.rs
+++ b/src/zombies.rs
@@ -61,7 +61,7 @@ fn spawn_zombies(
 
         // Spawn new zombie away from the player
         let player = player.single();
-        let origin = player.origin + random_displacement(2000, 3000);
+        let origin = player.origin + random_displacement(10000, 50000);
 
         debug!("Spawning at {origin:?}");
         commands
@@ -83,7 +83,7 @@ fn despawn_faraway_zombies(
     let player = player.single();
     for (transform, mut zombie) in zombies.iter_mut() {
         let distance = transform.origin.distance_to(player.origin);
-        if distance > 4000.0 {
+        if distance > 60000.0 {
             debug!(
                 "{:?} is too far from {:?} ({:?}). Despawning.",
                 transform.origin, player.origin, distance

--- a/src/zombies.rs
+++ b/src/zombies.rs
@@ -45,15 +45,27 @@ fn random_displacement(min_distance: u32, max_distance: u32) -> Vector2 {
 fn spawn_zombies(
     mut commands: Commands,
     player: Query<&Transform2D, With<Player>>,
+    zombies: Query<(), With<Zombie>>,
     mut timer: ResMut<SpawnTimer>,
     time: Res<Time>,
 ) {
     timer.0.tick(time.delta());
 
     if timer.0.just_finished() {
+
+        // Limit spawning rate if population is large
+        let population_target = 200.0;
+        let actual_population = zombies.iter().count() as f32;
+        let probability = population_target / 100.0 / actual_population.sqrt();
+        debug!("Current population is {actual_population}");
+        if random::<f32>() > probability { return };
+
+        // Spawn new zombie away from the player
         let player = player.single();
         let origin = player.origin + random_displacement(2000, 3000);
 
+
+        debug!("Spawning at {origin:?}");
         commands
             .spawn()
             .insert(GodotScene::from_path("res://Zombie.tscn"))

--- a/src/zombies.rs
+++ b/src/zombies.rs
@@ -29,7 +29,7 @@ impl Target {
     fn random() -> Self {
         let mut rng = thread_rng();
         let distance = rng.gen_range(100.0..1000.0);
-        let direction = rng.gen_range(0.0..PI);
+        let direction = rng.gen_range(0.0..(2.0 * PI));
         let vector = Vector2::UP.rotated(direction) * distance;
         Self(vector)
     }


### PR DESCRIPTION
With this work, zombies are spawned in a procedural way every 10s with a varying probability. The bigger the population, the less likely it is that a new zombie will spawn. The probability is inversely proportional to the square root of population. New zombies appear far away from the player (in a ring between 2000px and 3000px), and start roaming randomly. If they roam too far from the player (further than 4000px), they get de-spawned.

The intention is to simulate them coming from the vast wasteland around the player. In game is shouldn't feel like spawning, but like coming from a distance, or wandering away. To achieve this we will need to tweak the constants a bit.